### PR TITLE
significantly decrease size of resulting Wasm file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2021"
 [profile.dev.package.'*']
 opt-level = 3
 
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
 [dependencies]
 glam = "0.20.1"
 macroquad = "0.3"


### PR DESCRIPTION
Explanation about the flags:
- `opt-level = 3` is actually redundant and can be removed but I prefer to have it here to state the intent. Could also be `"z"` for smallest possible size.
- `lto = "fat"` means that we want full link-time-optimization support.
- `codegen-units = 1` means that we only want one codegen unit instead of the default which usually is 16. The effect is slower compile times for release mode but also improved optimization potential.
- `panic = "abort"` means that we do not want to have backtraces and exception-like behavior in our Wasm file which is not really bad since it is unsupported in Wasm atm anyways and just heavily bloats our Wasm file.

Using the above configs drop the Wasm file size from ~2MB to ~500kB on my local system.

Furthermore we could use a `wasm-opt -O3` pass over after the initial `cargo build --release` command.
On my system this further reduces the Wasm file size by roughly 10-15%.
The downside is that `wasm-opt` creates a dependency on the Binaryen toolkit which might not exist on your platform.